### PR TITLE
Add missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2309,9 +2309,9 @@
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.8",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.8.tgz",
-      "integrity": "sha512-aHhfHa0ma9e/H+yv5NA3ie0lRy5duwnUA5fNlGzvxlGMW7DPno+UffbMPZ/HQo3J3Oh7BdC/IDwSwvgucJHPkw==",
+      "version": "1.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.9.tgz",
+      "integrity": "sha512-ySB/GJsZV3h3jqjq5WIiaxVFkJK6vqtG9gS7Iw6SfUH9ZiFNw5JjQF69g68j9cNep3q4yRIYiG5/pI3YIdXEuA==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.1.0",
@@ -3370,6 +3370,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -5825,6 +5833,11 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -8950,6 +8963,11 @@
         "big-integer": "^1.6.16"
       }
     },
+    "nanoid": {
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9172,6 +9190,11 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object-path": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Mateo Morris",
   "license": "ISC",
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview"
@@ -75,6 +76,7 @@
     "@tiptap/extension-list-item": "^2.0.0-beta.1",
     "@tiptap/extension-ordered-list": "^2.0.0-beta.1",
     "@tiptap/starter-kit": "^2.0.0-beta.25",
+    "axios": "^0.21.1",
     "broadcast-channel": "^3.4.1",
     "clipboard": "^2.0.6",
     "codemirror": "^5.59.2",
@@ -87,6 +89,8 @@
     "jszip": "^3.6.0",
     "lz-string": "^1.4.4",
     "mousetrap": "^1.6.5",
+    "nanoid": "^3.1.22",
+    "object-path": "^0.11.5",
     "pluralize": "^8.0.0",
     "prettier": "^2.2.1",
     "prosemirror-commands": "^1.1.6",


### PR DESCRIPTION
Upon initial installation, a number of dependencies were missing from the `package.json` dependencies list.

Also adding a standard `npm start` script that does the same as `npm run dev`, since it is more common and a built-in script.